### PR TITLE
Adjust the size of each child

### DIFF
--- a/devsmartlib/src/com/devsmart/android/ui/HorizontalListView.java
+++ b/devsmartlib/src/com/devsmart/android/ui/HorizontalListView.java
@@ -151,8 +151,8 @@ public class HorizontalListView extends AdapterView<ListAdapter> {
 		}
 
 		addViewInLayout(child, viewPos, params, true);
-		child.measure(MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.AT_MOST),
-				MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.AT_MOST));
+		child.measure(MeasureSpec.makeMeasureSpec(params.width, MeasureSpec.AT_MOST),
+				MeasureSpec.makeMeasureSpec(params.height, MeasureSpec.AT_MOST));
 	}
 	
 	


### PR DESCRIPTION
When the children use images, these images has the same width as HorizontalListView and AdjustViewBounds doesn't work. See example: http://stackoverflow.com/questions/16134760/horizontallistview-custom-image-text-view

Changing getWidth() and getHeight() with params.width or params.height solves the problem.
