### PR TITLE
Fix display of HorizontalListView in graphical layout

### DIFF
--- a/devsmartlib/src/com/devsmart/android/ui/HorizontalListView.java
+++ b/devsmartlib/src/com/devsmart/android/ui/HorizontalListView.java
@@ -74,7 +74,8 @@ public class HorizontalListView extends AdapterView<ListAdapter> {
 		mNextX = 0;
 		mMaxX = Integer.MAX_VALUE;
 		mScroller = new Scroller(getContext());
-		mGesture = new GestureDetector(getContext(), mOnGesture);
+		if (!isInEditMode())
+			mGesture = new GestureDetector(getContext(), mOnGesture);
 	}
 	
 	@Override


### PR DESCRIPTION
GestureDetector caused an error in the graphical layout in Eclipse.
