### PR TITLE
Fixed HorizontalListView child element layout changes not being redrawn on the fly

### DIFF
--- a/devsmartlib/src/com/devsmart/android/ui/HorizontalListView.java
+++ b/devsmartlib/src/com/devsmart/android/ui/HorizontalListView.java
@@ -279,7 +279,17 @@ public class HorizontalListView extends AdapterView<ListAdapter> {
 			int left = mDisplayOffset;
 			for(int i=0;i<getChildCount();i++){
 				View child = getChildAt(i);
-				int childWidth = child.getMeasuredWidth();
+				
+				// We must make sure our measurements are up to date. 
+				// Layout changes within child views were not taken into account otherwise.
+				ViewGroup.LayoutParams params = child.getLayoutParams();
+			        if(params == null) {
+			          params = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
+			        }
+			        child.measure(MeasureSpec.makeMeasureSpec(params.width, MeasureSpec.AT_MOST),
+			                      MeasureSpec.makeMeasureSpec(params.height, MeasureSpec.AT_MOST));
+        
+        			int childWidth = child.getMeasuredWidth();
 				child.layout(left, 0, left + childWidth, child.getMeasuredHeight());
 				left += childWidth + child.getPaddingRight();
 			}


### PR DESCRIPTION
Changes to the size of view elements within one of the child views were not being reflected on screen (until scrolling the element out and then back in).
The issue was that the HorizontalListView.onLayout call wasn't re-measuring the child view in onLayout before laying it out.

This meant that the new text of a TextView was being truncated on screen as the view was not resizing itself.
